### PR TITLE
Remove shadow from additional buttons

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -98,8 +98,11 @@
     box-shadow: 0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
 }
 
-//flatten editor buttons
-.d-editor-button-bar .btn{
+//flatten editor, topic-map, more badges, and revision view buttons
+.d-editor-button-bar .btn,
+.topic-map .btn.no-text,
+.badge-section .btn,
+#revision .btn {
     border-radius: 0px;
     -webkit-box-shadow: 0 2px 5px 0 rgba(0,0,0,0),0 2px 10px 0 rgba(0,0,0,0);
     -moz-box-shadow: 0 2px 5px 0 rgba(0,0,0,0),0 2px 10px 0 rgba(0,0,0,0);


### PR DESCRIPTION
Relevant topic (with screenshots): https://meta.discourse.org/t/material-design-stock-theme/47142/178

Adding box-shadow to certain "buttons" look out of place.  This removes the shadow from the topic map expansion button, the +x more badges button on the user card, and the revision view buttons in the edit log.