### PR TITLE
Fix post highlight transition for mobile

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -63,3 +63,13 @@ aside.quote {
   -moz-box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
 }
+
+//Highlight Transition Color Fix
+@keyframes background-fade-highlight {
+  0% {
+    background-color: lighten($tertiary, 20%);
+  }
+  100% {
+    background-color: lighten($secondary, 10%);
+  }
+}


### PR DESCRIPTION
Similar to PR #7, but for the mobile version.  I do like the way css looks on the mobile.

Or, instead of using this PR, we should move some duplicate entries into common.css.