### PR TITLE
FIX: mobile avatars not contained within card

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -5,18 +5,23 @@
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
   background-color: lighten($secondary, 10%);
   margin-top: 10px;
-  padding-left: 20px;
+  padding: 20px;
   border-radius: 2px;
-  padding-right: 20px;
 }
 
 //more space for avatars
 .topic-avatar {
   border-top: 0;
-  padding-right: 10px;
+  padding-top: 20px;
+  padding-left: 10px;
   .avatar-flair {
     right: 4px;
   }
+}
+
+//increase space between post meta and post content
+.boxed .contents {
+  padding: 20px 0 0 0;
 }
 
 //remove stray border from bottom of last post


### PR DESCRIPTION
Adds padding to create enough space for mobile avatars to be contained within the card and to create a bit of breathing room under post action buttons (reply, like...)

Before:

https://preview.ibb.co/kAdJ2H/2.png

After:

https://preview.ibb.co/hy7d2H/1.png