### PR TITLE
Replace color variables

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -54,7 +54,7 @@ body textarea {
   max-width: 808px;
   button {
     margin-left: 1em;
-    background-color: lighten($secondary, 10%);
+    background-color: var(--material-lighter-secondary);
   }
 }
 

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -34,24 +34,24 @@
 //underline navigation links
 .nav-pills > li.active > a,
 .nav-pills > li > a.active {
-  color: $primary;
+  color: var(--primary);
   font-weight: 500;
-  background-color: $secondary;
-  border-bottom: 3px solid $tertiary;
+  background-color: var(--secondary);
+  border-bottom: 3px solid var(--tertiary);
 }
 
 //remove highlighting navigation background on hover
 .nav-pills > li > a:hover {
-  background-color: $secondary;
+  background-color: var(--secondary);
 }
 
 //fix color of user profile navigation icons
 .user-main .nav-pills {
   a.active i {
-    color: $primary;
+    color: var(--primary);
   }
   a:hover:not(.active) i {
-    color: $quaternary;
+    color: var(--quaternary);
   }
 }
 

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -5,7 +5,7 @@
 //create conversation cards
 .topic-body {
   @include boxShadow;
-  background-color: lighten($secondary, 10%);
+  background-color: var(--material-lighter-secondary);
   margin-top: 10px;
   padding: 20px;
   border-radius: 4px;


### PR DESCRIPTION
I've seen that @jordanvidrine reverted these variable changes in August 2020. I couldn't find why though. The colors don't get picked up correctly for me, but with the CSS properties they do.