### PR TITLE
UX: Update style for new PM bubbles, pin older

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+2.8.0.beta3: 7947c0a702bee2df957b0b8baab3b98eb5d91bda

--- a/common/common.scss
+++ b/common/common.scss
@@ -76,3 +76,14 @@ body textarea {
 .popup-menu .btn {
   box-shadow: none;
 }
+
+// Personal messages
+
+.archetype-private_message {
+  .topic-body {
+    box-shadow: none;
+    .cooked {
+      @include boxShadow;
+    }
+  }
+}

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -272,3 +272,14 @@
     }
   }
 }
+
+// Personal messages
+
+.archetype-private_message {
+  .topic-body {
+    margin-left: -2em;
+  }
+  .small-action {
+    max-width: 758px;
+  }
+}


### PR DESCRIPTION
Accommodating the new style, and pinning older versions of Discourse so they don't get the new style until they update

Before:
![Screen Shot 2021-07-23 at 11 32 26 AM](https://user-images.githubusercontent.com/1681963/126805731-b2d0bab2-3944-4883-85d2-98b6601198e8.png)
![Screen Shot 2021-07-23 at 11 32 30 AM](https://user-images.githubusercontent.com/1681963/126805754-07e88d2e-be86-4875-9a21-dbc38a32b92e.png)

After:
![Screen Shot 2021-07-23 at 11 26 06 AM](https://user-images.githubusercontent.com/1681963/126805738-598daf3c-1d03-4282-9f87-1837de454dcf.png)
![Screen Shot 2021-07-23 at 11 25 59 AM](https://user-images.githubusercontent.com/1681963/126805807-9fa75868-bc03-46ce-9ade-a741f18bf56f.png)


