### PR TITLE
UX: Add sidebar support

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -23,8 +23,10 @@ body textarea {
     0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
 }
 
+@import "sidebar";
+
 //raise and round buttons
-.btn {
+.btn:not(.sidebar-section-header, .header-sidebar-toggle button) {
   border-radius: 4px;
   @include boxShadow;
   &.btn-flat.close {

--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -1,0 +1,22 @@
+// Sidebar toggle styling
+.header-sidebar-toggle {
+  button {
+    .d-icon {
+      color: var(--tertiary);
+      box-shadow: none;
+    }
+
+    &:hover {
+      .d-icon {
+        color: var(--primary-med-or-secondary-med);
+      }
+    }
+  }
+}
+
+// Sidebar Style Overrides
+.sidebar-wrapper {
+  @include boxShadow;
+  margin-top: 2.4em;
+  background-color: var(--material-lighter-secondary);
+}


### PR DESCRIPTION
This PR adds styling to support Discourse's new sidebar. It styles the sidebar to match the theme as well as the sidebar header toggle.

**Before:**
<img width="1512" alt="Screen Shot 2022-08-31 at 10 50 18 AM" src="https://user-images.githubusercontent.com/30090424/187746099-74a279b0-a4b3-4ad3-88b8-0c5d66c7ca9f.png">


**After:**
<img width="1512" alt="Screen Shot 2022-08-31 at 10 50 32 AM" src="https://user-images.githubusercontent.com/30090424/187746122-cf9ec3cd-0569-44b0-b902-13e07bc06641.png">

