### PR TITLE
UX: minor chat layout fixes

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -1,17 +1,29 @@
 @import "common/foundation/variables";
 
 @mixin boxShadow {
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 0 0 0 rgba(0, 0, 0, 0.12);
+  box-shadow:
+    0 2px 5px 0 rgba(0, 0, 0, 0.16),
+    0 0 0 0 rgba(0, 0, 0, 0.12);
 }
 
 @mixin buttonShadow {
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+  box-shadow:
+    0 0 4px rgba(0, 0, 0, 0.14),
+    0 4px 8px rgba(0, 0, 0, 0.28);
 }
 
 @mixin buttonTransition {
-  transition: right 0.5s, bottom 0.5s, border-radius 0.5s, text-indent 0.2s,
-    visibility 1s, width 0.2s ease, height 0.5s ease 0.4s, color 0.5s,
-    background-color 2s, transform 0.5s;
+  transition:
+    right 0.5s,
+    bottom 0.5s,
+    border-radius 0.5s,
+    text-indent 0.2s,
+    visibility 1s,
+    width 0.2s ease,
+    height 0.5s ease 0.4s,
+    color 0.5s,
+    background-color 2s,
+    transform 0.5s;
 }
 
 // make header icons semi-translucent
@@ -294,11 +306,13 @@
 // Chat
 
 .chat-channel {
-  height: calc(100dvh - (var(--header-offset) + 3em));
+  height: calc(100dvh - (var(--header-offset) + 6em));
 }
 
 #main-chat-outlet {
   margin-top: 1.5em;
-  box-shadow: 0px 2px 1px -1px rgba(0, 0, 0, 0.2),
-    0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12);
+  box-shadow:
+    0px 2px 1px -1px rgba(0, 0, 0, 0.2),
+    0px 1px 1px 0px rgba(0, 0, 0, 0.14),
+    0px 1px 3px 0px rgba(0, 0, 0, 0.12);
 }

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,5 +1,7 @@
 @mixin boxShadow {
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 0 0 0 rgba(0, 0, 0, 0.12);
+  box-shadow:
+    0 2px 5px 0 rgba(0, 0, 0, 0.16),
+    0 0 0 0 rgba(0, 0, 0, 0.12);
 }
 
 //create conversation cards
@@ -59,10 +61,4 @@ aside.quote {
       left: 4px;
     }
   }
-}
-
-// Chat
-
-#main-chat-outlet {
-  margin-top: calc(var(--header-offset) - 1em);
 }


### PR DESCRIPTION
Couple minor chat fixes (prettier also applied to the shadows) 

Before: 

Too much top margin
![Screenshot 2023-12-21 at 2 09 33 PM](https://github.com/discourse/material-design-stock-theme/assets/1681963/5e61c21d-d93a-4ec5-9176-8c70643cf579)

Full-screen chat too tall due to margin
![Screenshot 2023-12-21 at 2 06 57 PM](https://github.com/discourse/material-design-stock-theme/assets/1681963/4e15b7f2-7295-4ffe-9a05-f5a20639f7da)

After:

![Screenshot 2023-12-21 at 2 09 27 PM](https://github.com/discourse/material-design-stock-theme/assets/1681963/85fbb36a-3656-4a7a-b30f-05ae2b0d2edf)


![Screenshot 2023-12-21 at 2 06 42 PM](https://github.com/discourse/material-design-stock-theme/assets/1681963/2709c46b-20f8-4af5-893d-add5dcf2c62b)

