### PR TITLE
UX: add styling for floating topic button edge cases

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -133,8 +133,10 @@
     bottom: 60px;
   }
 
-  body:has(#reply-control.draft.show-preview) & {
-    bottom: 60px;
+  @media screen and (max-width: 1520px) {
+    body:has(#reply-control.draft.show-preview) & {
+      bottom: 60px;
+    }
   }
 
   background-color: var(--tertiary);

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -127,6 +127,16 @@
   bottom: 30px;
   right: 50px;
   z-index: z("composer", "content") - 1;
+
+  .chat-drawer-active & {
+    z-index: z("chat-drawer") - 1;
+    bottom: 60px;
+  }
+
+  body:has(#reply-control.draft.show-preview) & {
+    bottom: 60px;
+  }
+
   background-color: var(--tertiary);
   color: var(--secondary);
   white-space: nowrap;


### PR DESCRIPTION
The floating topic button overlaps with the chat-drawer, reported https://meta.discourse.org/t/new-thread-button-covers-chat-input-area/320189

This commit:
* lowers the z-index of the button, ensuring it's lower than the chat-drawer
* adds conditional positioning to avoid the button overlapping with a minimised chat drawer or composer – it's not perfectly smart but it's an improvement for most states
