### PR TITLE
UX: improve new topic button, minor maintenance

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,3 +1,7 @@
+:root {
+  --d-header-icon-background--hover: var(--header_primary-low);
+}
+
 @font-face {
   font-family: Roboto;
   src: url($roboto);
@@ -46,14 +50,9 @@ body textarea {
 @import "sidebar";
 
 // raise and round buttons
-.btn:not(
-  .sidebar-section-header,
-  .header-sidebar-toggle button,
-  .user-menu-tab,
-  .btn-flat,
-  .btn-link,
-  .btn-transparent
-) {
+.btn-default,
+.btn-primary,
+.d-combo-button {
   border-radius: 4px;
 
   @include boxShadow;
@@ -150,7 +149,7 @@ body textarea {
 
 // Chat
 body.has-sidebar-page.has-full-page-chat #main-outlet-wrapper {
-  gap: 2em;
+  gap: 0 2em;
 }
 
 .has-full-page-chat:not(.discourse-sidebar) .full-page-chat {
@@ -192,4 +191,10 @@ body.has-sidebar-page.has-full-page-chat #main-outlet-wrapper {
   .assigned-to .d-icon {
     color: var(--secondary);
   }
+}
+
+.topic-voting-menu-trigger {
+  // overrides some very specific button styles
+  border-bottom-left-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
 }

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -39,7 +39,6 @@
 // add shadow behind topics in Latest view
 .category-list,
 .topic-list,
-.column,
 .latest-topic-list {
   @include boxShadow;
   background-color: var(--material-lighter-secondary);
@@ -118,17 +117,16 @@
 }
 
 // New Topic Fab
-#create-topic.btn-default {
+.d-combo-button:has(#create-topic) {
   display: flex;
   align-items: center;
   justify-content: center;
 
   @include buttonShadow;
   @include buttonTransition;
-  padding: 0;
   margin: 0;
-  width: 63px;
   height: 63px;
+  width: 190px;
   border-radius: 40px;
   position: fixed;
   bottom: 30px;
@@ -138,6 +136,21 @@
   color: var(--secondary);
   white-space: nowrap;
   overflow: hidden;
+
+  .d-button-label {
+    color: var(--secondary);
+  }
+
+  button {
+    background: transparent;
+    box-shadow: none;
+    height: 100%;
+  }
+
+  .topic-drafts-menu-trigger {
+    border-left: 1px solid var(--secondary);
+    padding-left: 1em;
+  }
 
   .chat-drawer-active & {
     z-index: z("chat-drawer") - 1;
@@ -160,26 +173,10 @@
     transition: all 0.3s;
     margin: 0 0.25em;
   }
-
-  &:not(:hover, :active, :focus) {
-    .d-button-label {
-      opacity: 0;
-      width: 0;
-      margin: 0;
-    }
-
-    .d-icon {
-      margin: 0 0.25em;
-    }
-  }
 }
 
 #create-topic.btn-default .fa-plus {
   color: var(--secondary);
-}
-
-#create-topic.btn-default:hover {
-  width: 190px;
 }
 
 .timeline-container .topic-timeline .timeline-handle {


### PR DESCRIPTION
Our new topic button with the draft dropdown required some reworking here... 

Before (draft button is entirely separate):
<img height="400" alt="image" src="https://github.com/user-attachments/assets/82b36bfd-db9b-41ae-b66f-4828e4176d0b" />

After (combined buttons, but lose the hover effect): 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8c843667-91a0-4e55-ae5c-6a0fcc5da5c6" />

I also reduced the scope of general button box-shadows, because the `.btn` selector is way too braod and our coverage for `btn-default` and `btn-primary` is much better than it used to be. This results in fewer cases of buttons getting box-shadows then they should not. 

Also includes a minor chat gap fix and a small border-radius adjustment for the new topic voting style.